### PR TITLE
add publishing to mavenlocal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ val mockkVersion: String by project
 
 plugins {
     kotlin("multiplatform") version "1.3.61"
+    id("maven-publish")
 }
 
 group = "com.github.nwillc"
@@ -40,8 +41,20 @@ repositories {
 }
 
 kotlin {
-    jvm()
-    js()
+    jvm() {
+        mavenPublication { // Setup the publication for the target
+//            artifactId = "ksvg-jvm"
+            // Add a docs JAR artifact (it should be a custom task):
+//            artifact(javadocJar)
+        }
+    }
+    js() {
+        mavenPublication { // Setup the publication for the target
+//            artifactId = "ksvg-js"
+            // Add a docs JAR artifact (it should be a custom task):
+//            artifact(javadocJar)
+        }
+    }
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,22 @@ kotlin {
         }
     }
     js() {
+        useCommonJs()
+        browser {
+            runTask {
+                sourceMaps = true
+            }
+            webpackTask {
+                sourceMaps = true
+            }
+        }
+        compilations.all {
+            kotlinOptions {
+                sourceMap = true
+                metaInfo = true
+                main = "call"
+            }
+        }
         mavenPublication { // Setup the publication for the target
 //            artifactId = "ksvg-js"
             // Add a docs JAR artifact (it should be a custom task):


### PR DESCRIPTION
I was also looking around for ho to add bintray again

seems like jetbrains uses their own plugin to configure multiplatform deployment and teamcity integration https://github.com/Kotlin/kotlinx.team.infra

and i found this writeup, not sure if it is still correct: https://natanfudge.github.io/fudgedocs/publish-kotlin-mpp-lib.html

another example i found: https://github.com/data2viz/data2viz/blob/master/build.gradle#L36-L38
https://github.com/data2viz/data2viz/blob/master/gradle/publish-bintray.gradle


never used bintray myself, seems to be a pain